### PR TITLE
Add outdated command

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -101,7 +101,8 @@ func genGomfile(directory string) error {
 	for _, pkg := range all {
 		fmt.Fprintf(f, "gom '%s'\n", pkg)
 	}
-	return update()
+
+	return nil
 }
 
 func genGomfileLock() error {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func usage() {
    gom run         [options]   : Run go file with bundles
    gom doc         [options]   : Run godoc for bundles
    gom exec        [arguments] : Execute command with bundle environment
-   gom update                  : Check and update to newer versions
+   gom outdated                : Display outdated packages
    gom tool        [options]   : Run go tool with bundles
    gom check                   : Check if the vendored dependencies match the Gomfile
    gom fmt         [arguments] : Run go fmt
@@ -60,8 +60,8 @@ func main() {
 	var err error
 	subArgs := flag.Args()[1:]
 	switch flag.Arg(0) {
-	case "update", "u":
-		err = update()
+	case "outdated":
+		err = outdated()
 	case "install", "i":
 		err = install(subArgs)
 	case "check":


### PR DESCRIPTION
For instance we now can see outdated packages:

```
$ gom outdated
github.com/joho/godotenv/cmd/godotenv
  \_ Latest version: 4ed13390c0acd2ff4e371e64d8b97c8954138243
  \_ Tree: http://github.com/joho/godotenv/tree/4ed13390c0acd2ff4e371e64d8b97c8954138243
  \_ Compare changes: http://github.com/joho/godotenv/compare/443e926da0d793d3b3f32118b1e4ba52ada26503...4ed13390c0acd2ff4e371e64d8b97c8954138243
github.com/kisielk/errcheck
  \_ Latest version: a4f12b02dc24fba8e9cd3706f3c35795616f2687
  \_ Tree: http://github.com/kisielk/errcheck/tree/a4f12b02dc24fba8e9cd3706f3c35795616f2687
  \_ Compare changes: http://github.com/kisielk/errcheck/compare/50b84cf7fa18ee2985b8c63ba3de5edd604b9259...a4f12b02dc24fba8e9cd3706f3c35795616f2687
...
```
