### PR TITLE
Make checkStaleness() recursively check for a Gomfile

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/daviddengcn/go-colortext"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/daviddengcn/go-colortext"
 )
 
 type Color int
@@ -74,7 +75,7 @@ func ready() error {
 
 var stdout = os.Stdout
 var stderr = os.Stderr
-var stdin  = os.Stdin
+var stdin = os.Stdin
 
 func run(args []string, c Color) error {
 	if err := ready(); err != nil {
@@ -86,7 +87,7 @@ func run(args []string, c Color) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	cmd.Stdin  = stdin
+	cmd.Stdin = stdin
 	ct.ChangeColor(ct.Color(c), true, ct.None, false)
 	err := cmd.Run()
 	ct.ResetColor()


### PR DESCRIPTION
Presently, `gom exec` does look in parent directories for a Gomfile allowing to `gom exec foobar` while being in nested folders in the project hierarchy, but it calls `checkStaleness()` **which just looks for a Gomfile in the current path**. 

This breaks vim-go `:GoRename` and it's probably affecting other go plugins used by others editors. 

This PR fixes it. 
